### PR TITLE
Galley API spec

### DIFF
--- a/api/galley/v1/config_object.proto
+++ b/api/galley/v1/config_object.proto
@@ -1,0 +1,112 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+import "google/protobuf/struct.proto";
+
+import "api/galley/v1/metadata.proto";
+
+// This file defines the file format used by the Galley file system api.
+
+// A configuration file stored at a location.
+// A file must have a *.cfg extension.
+// A config file consists of ConfigOjects organized in named ObjectCollections.
+// Object collections provide organizational aid to the file author.
+// File also represents a directory if the name does not have a *.cfg extension.
+// A directory contains no data.
+message ConfigFile{
+
+  // The scope this config file applies to.
+  // Every directory may contain files with multiple scopes.
+  // A config file asserts its scope as a dns suffix.
+  // myservice.mydept.acme.com or mydept.acme.com.
+  // A service scope means that the document contains configuration
+  // that is owned by and affects the service. Similarly one level higher scope
+  // like mydept.acme.com may affect self and any of the services contained in that namespace.
+  // All configuration in the file must be contained within the scope.
+  string scope = 1;
+  
+  // metadata associated with the file. Optional.
+  Metadata metadata = 2;
+
+  // metadata assigned by the server. Cannot be changed by the client.
+  ServerMetadata serverMetadata =  3;
+  
+  repeated ConfigObjectCollection config = 4;
+}
+
+// The basic atom of configuration as understood 
+// by Istio components
+message ConfigObject{
+  // metrics, route-rule are config “types”. Required.
+  string type = 1;
+
+  // name of the object.
+  string name = 2;
+
+  // metadata about the object
+  Metadata metadata = 3;
+
+  // spec is 'type' specific configuration specified in json / yaml format.
+  // This contains everything that was submitted by the user.
+  // spec is validated by Validators.
+  google.protobuf.Struct spec = 4;
+
+  // processed_spec is the binary encoded protobuf.
+  // For example:
+  // If `spec` contains an expressions in text form 
+  // `processed_spec` may contain a parsed AST or an optimized
+  // expression.
+  // It is up to the component performing validation and
+  // transformation to make use of this field.
+  bytes processed_spec = 5; 
+}
+
+// ConfigObjectCollection is an arbitrary operator specified
+// partitioning of the ConfigObjests.
+message ConfigObjectCollection{
+  // name of the object collection.
+  string name = 1;
+
+  // metadata about the collection.
+  Metadata metadata = 2;
+
+  repeated ConfigObject objects = 3;
+}
+
+// A change to the galley config store.
+message ConfigChange {
+  enum EventType {
+    PUT = 0;  // ADD and UPDATE
+    DELETE = 1;
+  }
+  // If type is a PUT, it indicates that
+  // new data has been stored to the key. If type is a DELETE,
+  // it indicates the key was deleted.
+  EventType type = 1;
+
+  // Id of the config file that changed.
+  // This may be used to compare for equality but should not be otherwise interpreted.
+  string uid = 2;
+
+  // A PUT event contains current value.
+  // A DELETE event contains the deleted key with
+  // its modification revision set to the revision of deletion.
+  ConfigFile value = 3;
+
+  // value before the operation was done. Optional.
+  ConfigFile prev_value = 4;
+}

--- a/api/galley/v1/file_example.yaml
+++ b/api/galley/v1/file_example.yaml
@@ -51,11 +51,4 @@ config:
             version: v2
           weight: 10
 
-  - name: mapping
-    objects:
-    - type: mapping
-      spec:
-        self: ["com.acme"]
-        mapping:
-          dept1: 
-            subdomains: ["com.acme.dept1"]
+

--- a/api/galley/v1/file_example.yaml
+++ b/api/galley/v1/file_example.yaml
@@ -1,0 +1,61 @@
+metadata:
+  labels:
+    name: myserviceconfig
+config:
+  - name: metric-rq
+    objects:
+    - type: constructor
+      name: request_count
+      spec:
+        value: request.size
+        labels:
+          service: target.service
+          dc: target.data_center
+    - type: handler
+      name: mystatsd
+      spec:
+        impl: istio.io/statsd
+        params:
+          host: statshost.FQDN
+          port: 9080
+    - type: rule
+      spec:
+        selector: target.service == "service1.FQDN"
+        handler: $mystatsd
+        instances:
+        - $request_count
+
+  - name: denychecker
+    objects:
+    - type: constructor
+      name: deny_source_ip
+      spec:
+        value: request.source_ip
+    - type: rule
+      spec:
+        selector: target.service == "service1.FQDN" && source.labels["app"] != "billing"
+        handler: $mesh.denyhandler
+        instances:
+        - $deny_source_ip
+
+  - name: svc1-rules
+    objects:
+    - type: route-rule
+      spec:
+        destination: service1.FQDN
+        route:
+        - tags:
+            version: v1
+          weight: 90
+        - tags:
+            version: v2
+          weight: 10
+
+  - name: mapping
+    objects:
+    - type: mapping
+      spec:
+        self: ["com.acme"]
+        mapping:
+          dept1: 
+            subdomains: ["com.acme.dept1"]

--- a/api/galley/v1/metadata.proto
+++ b/api/galley/v1/metadata.proto
@@ -1,0 +1,33 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+message ServerMetadata {
+  // revision of the repository, the last time File was updated.
+  // assgined by the server.
+  int64 revision = 1;
+
+  // Effective scopes computed by the server.
+  // scope is computed using the optional scopes.yml in the directory.
+  // Individual files in the directory are only allowed to assert one of these
+  // scopes.
+  repeated string scopes = 2;
+}
+
+message Metadata {
+  // arbitrary labels.
+  map<string, string> labels = 1;
+}

--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -16,8 +16,9 @@ syntax = "proto3";
 package istio.galley.v1;
 
 import "google/api/annotations.proto";
-import "google/protobuf/struct.proto";
-import "google/rpc/status.proto";
+import "google/protobuf/empty.proto";
+
+import "api/galley/v1/metadata.proto";
 
 // Galley uses a hierarchical resource model.
 //
@@ -26,14 +27,17 @@ import "google/rpc/status.proto";
 //
 // Every directory contains a mapping that maps it's subdirectories
 // to a subdomain. The subdomains are expressed in reverse dns notation
-// like java package names. ex: com.google 
+// like java package names. ex: com.google
+// subdomains define a scope that the configuration cannot exceed.
 //
-// A directory has one or more config files with a .yaml extension.
-// A directory is a special file without the .yaml extension and with no content.
+// A directory has one or more config files with a .cfg extension.
+// A directory is a special file without the .cfg extension and with no content.
 // Galley understands the mapping between config "types" and the components
 // that process them.
 service Galley {
-  // Get a config file (or directory).
+  // Get contents of a file (or directory).
+  // Directory has no content so always returns empty.
+  // Get can be used to check the existence of a directory.
   rpc GetFile(GetFileRequest) returns (File) {
     option (google.api.http) = {
       get: "/v1/{path=**}"
@@ -41,7 +45,9 @@ service Galley {
   };
 
   // Delete a config file (or directory).
-  rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {
+  // A delete operation may fail validation due to referential integrity checks.
+  // google.rpc.Status.details contains reasons for the failure as ValidationErrors.
+  rpc DeleteFile(DeleteFileRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/v1/{path=**}"
     };
@@ -59,7 +65,9 @@ service Galley {
   }
 
   // Create a config file (or directory).
-  rpc CreateFile(UpdateFileRequest) returns (UpdateFileResponse) {
+  // Creation of a config file may fail due to validation errors.
+  // google.rpc.Status.details contains reasons for the failure as ValidationErrors.
+  rpc CreateFile(CreateFileRequest) returns (File) {
     option (google.api.http) = {
       post: "/v1/{path=**}"
       body: "file"
@@ -67,12 +75,23 @@ service Galley {
   };
 
   // Update a config file (or directory).
-  rpc UpdateFile(UpdateFileRequest) returns (UpdateFileResponse) {
+  // May be used to create or update a new file.
+  // Updating a config file may fail due to validation errors.
+  // google.rpc.Status.details contains reasons for the failure as ValidationErrors.
+  rpc UpdateFile(UpdateFileRequest) returns (File) {
     option (google.api.http) = {
       put: "/v1/{path=**}"
       body: "file"
     };
   };
+}
+
+message CreateFileRequest {
+   // path of the entry from root.
+  string path = 1;
+
+  // config file if the path refers to a file.
+  File file = 2;
 }
 
 message UpdateFileRequest {
@@ -83,45 +102,8 @@ message UpdateFileRequest {
   File file = 2;
 }
 
-// UpdateFileResponse is returned when an attempt is made to update a file.
-// ADD or UPDATE operations.
-message UpdateFileResponse {
-  // result of the operation
-  // if status == INVALID_ARGUMENT
-  // check errors for details.
-  google.rpc.Status status = 1; 
-
-  // config file after the change.
-  File file = 2;
-
-  // errors if st
-  repeated ValidationError validation_errors = 3;
-}
-
-// DeleteFileResponse is returned when an attempt is made to delete a file.
-message DeleteFileResponse {
-  // result of the operation
-  // if status == INVALID_ARGUMENT
-  // check errors for details.
-  google.rpc.Status status = 1; 
-
-  repeated ValidationError validation_errors = 2;
-}
-
-message ValidationError {
-  // The key of the object where error was detected.
-  // This may not be the object that introduced the error.
-  string key = 1;
-  // The primary field that was in error, if available.
-  string field = 2;
-  // The line number on which error occurred, if available.
-  int32 line_number = 3;
-  // Textual error message.
-  string error = 4;
-}
-
 // Contains path and
-// an optional File on available if this entry is not a ConfigNode.
+// an optional File available if this entry is not a directory.
 message ConfigEntry{
   // path of the entry from root.
   string path = 1;
@@ -146,7 +128,7 @@ message ListFilesRequest{
   // recurse thru the hierarchy. 
   bool recurse = 2;
 
-  // include data along with keys.
+  // include file contents along with keys.
   bool include_data = 3;
 
   // paged result, set to empty on first page.
@@ -167,115 +149,12 @@ message DeleteFileRequest{
 }
 
 // A configuration file stored at a location.
-// A file must have a *.yaml extension.
-// A config file consists of ConfigOjects organized in named ObjectCollections.
-// Object collections provide organizational aid to the file author.
-// File also represents a directory if the name does not have a *.yaml extension.
+// A file must have a *.cfg extension.
+// File also represents a directory if the name does not have a *.cfg extension.
 // A directory contains no data.
 message File{
-  // metadata associated with the file. Optional.
-  Metadata metadata = 1;
+  bytes contents = 1;
 
   // metadata assigned by the server. Cannot be changed by the client.
   ServerMetadata serverMetadata =  2;
-  
-  repeated ConfigObjectCollection config = 3;
-}
-
-// The basic atom of configuration as understood 
-// by Istio components
-message ConfigObject{
-  // metrics, route-rule are config “types”. Required.
-  string type = 1;
-
-  // name of the object collection.
-  string name = 2;
-
-  // metadata about the object
-  Metadata metadata = 3;
-
-  // spec is 'type' specific configuration specified in json / yaml format.
-  // This contains everything that was submitted by the user.
-  // spec is validated by Validators.
-  google.protobuf.Struct spec = 4;
-
-  // processed_spec is the binary encoded protobuf.
-  // For example:
-  // If `spec` contains an expressions in text form 
-  // `processed_spec` may contain a parsed AST or an optimized
-  // expression.
-  // It is up to the component performing validation and
-  // transformation to make use of this field.
-  bytes processed_spec = 5; 
-}
-
-// ConfigObjectCollection is an arbitrary operator specified
-// partitioning of the ConfigObjests.
-message ConfigObjectCollection{
-  // name of the object collection.
-  string name = 1;
-
-  // metadata about the collection.
-  Metadata metadata = 2;
-
-  repeated ConfigObject objects = 3;
-}
-
-message Metadata {
-  // arbitrary labels.
-  map<string, string> labels = 1;
-}
-
-message ServerMetadata {
-  // revision of the repository, the last time File was updated.
-  // assgined by the server.
-  int64 revision = 1;
-
-  // uuid assigned to the file. Only used when a new file is created 
-  // in the same place as before.
-  string uuid = 2;
-
-  // Effective subdomain computed at the server.
-  // subdomain is computed using the optional mappings.yml in the directory.
-  Subdomains effective_subdomains = 3;
-}
-
-// A change to the galley config store.
-message ChangeEvent {
-  enum EventType {
-    PUT = 0;  // ADD and UPDATE
-    DELETE = 1;
-  }
-  // If type is a PUT, it indicates that
-  // new data has been stored to the key. If type is a DELETE,
-  // it indicates the key was deleted.
-  EventType type = 1;
-
-  // The location associated with this value.
-  // This may be used to compare for equality but cannot be otherwise interpreted.
-  string path = 2;
-
-  // A PUT event contains current value.
-  // A DELETE event contains the deleted key with
-  // its modification revision set to the revision of deletion.
-  File value = 3;
-
-  // value before the operation was done. Optional.
-  File prev_value = 4;
-}
-
-// DomainMap specifies how to compute the effective subdomain of a directory
-message DomainMap {
-  // asserted subdomains of this directory
-  // "/" is allowed to assert anything
-  // All other directories may only assert what is permitted by the parent.
-  repeated string self = 1;
-
-  // map a subdirectory to a set of permitted subdomains. 
-  map<string, Subdomains> mapping = 2; 
-
-}
-
-message Subdomains {
-  repeated string subdomains = 1;
 }

--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -1,0 +1,265 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
+import "google/rpc/status.proto";
+
+// Galley uses a hierarchical resource model.
+//
+// Directories are organizational units that can be protected by ACLs.
+// ACLs are enforced and managed externally.
+//
+// Every directory contains a mapping that maps it's subdirectories
+// to a subdomain. The subdomains are expressed in reverse dns notation
+// like java package names. ex: com.google 
+//
+// A directory has one or more config files with a .yaml extension.
+// A directory is a special file without the .yaml extension and with no content.
+// Galley understands the mapping between config "kinds" and the components
+// that process them.
+service Galley {
+  // Get a config file (or directory).
+  rpc GetConfigFile(GetConfigFileRequest) returns (ConfigFile) {
+    option (google.api.http) = {
+      get: "/v1/{path=**}"
+    };
+  };
+
+  // Delete a config file (or directory).
+  rpc DeleteConfigFile(DeleteConfigFileRequest) returns (DeleteConfigFileResponse) {
+    option (google.api.http) = {
+      delete: "/v1/{path=**}"
+    };
+  };
+
+  // List config files.
+	// A note on http mapping.
+	// google.api.http permits the multi segment match '**' operator as the last match only, 
+	// except when :VERB is used. Here we use :list verb to disambiguate between
+	// GET on a file and GET on a directory.
+  rpc ListConfigFiles(ListConfigFilesRequest) returns (ListConfigFilesResponse) {
+    option (google.api.http) = {
+      get: "/v1/{path=**}:list"
+    };
+  }
+
+  // Create a config file (or directory).
+  rpc CreateConfigFile(UpdateConfigFileRequest) returns (UpdateConfigFileResponse) {
+    option (google.api.http) = {
+      post: "/v1/{path=**}"
+      body: "file"
+    };
+  };
+
+  // Update a config file (or directory).
+  rpc UpdateConfigFile(UpdateConfigFileRequest) returns (UpdateConfigFileResponse) {
+    option (google.api.http) = {
+      put: "/v1/{path=**}"
+      body: "file"
+    };
+  };
+}
+
+message UpdateConfigFileRequest {
+   // path of the entry from root.
+  string path = 1;
+
+  // config file if the path refers to a file.
+  ConfigFile file = 2;
+}
+
+// UpdateConfigFileResponse is returned when an attempt is made to update a file.
+// ADD or UPDATE operations.
+message UpdateConfigFileResponse {
+  // result of the operation
+  // if status == INVALID_ARGUMENT
+  // check errors for details.
+  google.rpc.Status status = 1; 
+
+  // config file after the change.
+  ConfigFile file = 2;
+
+  // errors if st
+  repeated ValidationError validation_errors = 3;
+}
+
+// DeleteConfigFileResponse is returned when an attempt is made to delete a file.
+message DeleteConfigFileResponse {
+  // result of the operation
+  // if status == INVALID_ARGUMENT
+  // check errors for details.
+  google.rpc.Status status = 1; 
+
+  repeated ValidationError validation_errors = 2;
+}
+
+message ValidationError {
+  // The key of the object where error was detected.
+  // This may not be the object that introduced the error.
+  string key = 1;
+  // The primary field that was in error, if available.
+  string field = 2;
+  // The line number on which error occurred, if available.
+  int32 line_number = 3;
+  // Textual error message.
+  string error = 4;
+}
+
+// Contains path and
+// an optional ConfigFile on available if this entry is not a ConfigNode.
+message ConfigEntry{
+  // path of the entry from root.
+  string path = 1;
+
+  // config file.
+  ConfigFile file = 2;
+}
+
+message ListConfigFilesResponse{
+  // if include_data is specified, this includes the file.
+  repeated ConfigEntry entries = 1;
+
+  // If next_page_token is not empty, this is a paged result.
+  // use this value in the next request.
+  string next_page_token = 2;
+}
+
+message ListConfigFilesRequest{
+  // path of the directory from root.
+  string path = 1;
+
+  // recurse thru the hierarchy. 
+  bool recurse = 2;
+
+  // include data along with keys.
+  bool include_data = 3;
+
+  // paged result, set to empty on first page.
+  string page_token = 4;
+
+  // If non zero, response should have at most these number of entries.
+  int32 max_page_size = 5;
+}
+
+message GetConfigFileRequest{
+  // path of the config file from root.
+  string path = 1; 
+}
+
+message DeleteConfigFileRequest{
+  // path of the config file from root.
+  string path = 1; 
+}
+
+// A configuration file stored at a location.
+// A file must have a *.yaml extension.
+// A config file consists of ConfigOjects organized in named ObjectCollections.
+// Object collections provide organizational aid to the file author.
+// ConfigFile also represents a directory if the name does not have a *.yaml extension.
+// A directory contains no data.
+message ConfigFile{
+  // metadata associated with the file. Optional.
+  Metadata metadata = 1;
+
+  // metadata assigned by the server. Cannot be changed by the client.
+  ServerMetadata serverMetadata =  2;
+  
+  repeated ConfigObjectCollection config = 3;
+}
+
+// The basic atom of configuration as understood 
+// by Istio components
+message ConfigObject{
+  // metrics, route-rule are config “kinds”. Required.
+  string kind = 1;
+
+  // name of the object collection.
+  string name = 2;
+
+  // metadata about the object
+  Metadata metadata = 3;
+
+  // spec is 'kind' specific configuration specified in json / yaml format.
+  // This contains everything that was submitted by the user.
+  // spec is validated by Validators.
+  google.protobuf.Struct spec = 4;
+
+  // processed_spec is the binary encoded protobuf.
+  // For example:
+  // If `spec` contains an expressions in text form 
+  // `processed_spec` may contain a parsed AST or an optimized
+  // expression.
+  // It is up to the component performing validation and
+  // transformation to make use of this field.
+  bytes processed_spec = 5; 
+}
+
+// ConfigObjectCollection is an arbitrary operator specified
+// partitioning of the ConfigObjests.
+message ConfigObjectCollection{
+  // name of the object collection.
+  string name = 1;
+
+  // metadata about the collection.
+  Metadata metadata = 2;
+
+  repeated ConfigObject objects = 3;
+}
+
+message Metadata {
+  // arbitrary labels.
+  map<string, string> labels = 1;
+}
+
+message ServerMetadata {
+  // revision of the repository, the last time File was updated.
+  // assgined by the server.
+  int64 revision = 1;
+
+  // uuid assigned to the file. Only used when a new file is created 
+  // in the same place as before.
+  string uuid = 2;
+
+  // Effective scope computed at the server.
+  // scope is computed using mappings.yml available in every directory.
+  string effective_scope = 3;
+}
+
+// A change to the galley config store.
+message ChangeEvent {
+  enum EventType {
+    PUT = 0;  // ADD and UPDATE
+    DELETE = 1;
+  }
+  // type is the kind of event. If type is a PUT, it indicates
+  // new data has been stored to the key. If type is a DELETE,
+  // it indicates the key was deleted.
+  EventType type = 1;
+
+  // The location associated with this value.
+  // This may be used to compare for equality but cannot be otherwise interpreted.
+  string path = 2;
+
+  // A PUT event contains current value.
+  // A DELETE event contains the deleted key with
+  // its modification revision set to the revision of deletion.
+  ConfigFile value = 3;
+
+  // value before the operation was done. Optional.
+  ConfigFile prev_value = 4;
+}

--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -30,36 +30,36 @@ import "google/rpc/status.proto";
 //
 // A directory has one or more config files with a .yaml extension.
 // A directory is a special file without the .yaml extension and with no content.
-// Galley understands the mapping between config "kinds" and the components
+// Galley understands the mapping between config "types" and the components
 // that process them.
 service Galley {
   // Get a config file (or directory).
-  rpc GetConfigFile(GetConfigFileRequest) returns (ConfigFile) {
+  rpc GetFile(GetFileRequest) returns (File) {
     option (google.api.http) = {
       get: "/v1/{path=**}"
     };
   };
 
   // Delete a config file (or directory).
-  rpc DeleteConfigFile(DeleteConfigFileRequest) returns (DeleteConfigFileResponse) {
+  rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {
     option (google.api.http) = {
       delete: "/v1/{path=**}"
     };
   };
 
   // List config files.
-	// A note on http mapping.
-	// google.api.http permits the multi segment match '**' operator as the last match only, 
-	// except when :VERB is used. Here we use :list verb to disambiguate between
-	// GET on a file and GET on a directory.
-  rpc ListConfigFiles(ListConfigFilesRequest) returns (ListConfigFilesResponse) {
+  // A note on http mapping.
+  // google.api.http permits the multi segment match '**' operator as the last match only, 
+  // except when :VERB is used. Here we use :list verb to disambiguate between
+  // GET on a file and GET on a directory.
+  rpc ListFiles(ListFilesRequest) returns (ListFilesResponse) {
     option (google.api.http) = {
       get: "/v1/{path=**}:list"
     };
   }
 
   // Create a config file (or directory).
-  rpc CreateConfigFile(UpdateConfigFileRequest) returns (UpdateConfigFileResponse) {
+  rpc CreateFile(UpdateFileRequest) returns (UpdateFileResponse) {
     option (google.api.http) = {
       post: "/v1/{path=**}"
       body: "file"
@@ -67,7 +67,7 @@ service Galley {
   };
 
   // Update a config file (or directory).
-  rpc UpdateConfigFile(UpdateConfigFileRequest) returns (UpdateConfigFileResponse) {
+  rpc UpdateFile(UpdateFileRequest) returns (UpdateFileResponse) {
     option (google.api.http) = {
       put: "/v1/{path=**}"
       body: "file"
@@ -75,31 +75,31 @@ service Galley {
   };
 }
 
-message UpdateConfigFileRequest {
+message UpdateFileRequest {
    // path of the entry from root.
   string path = 1;
 
   // config file if the path refers to a file.
-  ConfigFile file = 2;
+  File file = 2;
 }
 
-// UpdateConfigFileResponse is returned when an attempt is made to update a file.
+// UpdateFileResponse is returned when an attempt is made to update a file.
 // ADD or UPDATE operations.
-message UpdateConfigFileResponse {
+message UpdateFileResponse {
   // result of the operation
   // if status == INVALID_ARGUMENT
   // check errors for details.
   google.rpc.Status status = 1; 
 
   // config file after the change.
-  ConfigFile file = 2;
+  File file = 2;
 
   // errors if st
   repeated ValidationError validation_errors = 3;
 }
 
-// DeleteConfigFileResponse is returned when an attempt is made to delete a file.
-message DeleteConfigFileResponse {
+// DeleteFileResponse is returned when an attempt is made to delete a file.
+message DeleteFileResponse {
   // result of the operation
   // if status == INVALID_ARGUMENT
   // check errors for details.
@@ -121,16 +121,16 @@ message ValidationError {
 }
 
 // Contains path and
-// an optional ConfigFile on available if this entry is not a ConfigNode.
+// an optional File on available if this entry is not a ConfigNode.
 message ConfigEntry{
   // path of the entry from root.
   string path = 1;
 
   // config file.
-  ConfigFile file = 2;
+  File file = 2;
 }
 
-message ListConfigFilesResponse{
+message ListFilesResponse{
   // if include_data is specified, this includes the file.
   repeated ConfigEntry entries = 1;
 
@@ -139,7 +139,7 @@ message ListConfigFilesResponse{
   string next_page_token = 2;
 }
 
-message ListConfigFilesRequest{
+message ListFilesRequest{
   // path of the directory from root.
   string path = 1;
 
@@ -156,12 +156,12 @@ message ListConfigFilesRequest{
   int32 max_page_size = 5;
 }
 
-message GetConfigFileRequest{
+message GetFileRequest{
   // path of the config file from root.
   string path = 1; 
 }
 
-message DeleteConfigFileRequest{
+message DeleteFileRequest{
   // path of the config file from root.
   string path = 1; 
 }
@@ -170,9 +170,9 @@ message DeleteConfigFileRequest{
 // A file must have a *.yaml extension.
 // A config file consists of ConfigOjects organized in named ObjectCollections.
 // Object collections provide organizational aid to the file author.
-// ConfigFile also represents a directory if the name does not have a *.yaml extension.
+// File also represents a directory if the name does not have a *.yaml extension.
 // A directory contains no data.
-message ConfigFile{
+message File{
   // metadata associated with the file. Optional.
   Metadata metadata = 1;
 
@@ -185,8 +185,8 @@ message ConfigFile{
 // The basic atom of configuration as understood 
 // by Istio components
 message ConfigObject{
-  // metrics, route-rule are config “kinds”. Required.
-  string kind = 1;
+  // metrics, route-rule are config “types”. Required.
+  string type = 1;
 
   // name of the object collection.
   string name = 2;
@@ -194,7 +194,7 @@ message ConfigObject{
   // metadata about the object
   Metadata metadata = 3;
 
-  // spec is 'kind' specific configuration specified in json / yaml format.
+  // spec is 'type' specific configuration specified in json / yaml format.
   // This contains everything that was submitted by the user.
   // spec is validated by Validators.
   google.protobuf.Struct spec = 4;
@@ -235,9 +235,9 @@ message ServerMetadata {
   // in the same place as before.
   string uuid = 2;
 
-  // Effective scope computed at the server.
-  // scope is computed using mappings.yml available in every directory.
-  string effective_scope = 3;
+  // Effective subdomain computed at the server.
+  // subdomain is computed using the optional mappings.yml in the directory.
+  Subdomains effective_subdomains = 3;
 }
 
 // A change to the galley config store.
@@ -246,7 +246,7 @@ message ChangeEvent {
     PUT = 0;  // ADD and UPDATE
     DELETE = 1;
   }
-  // type is the kind of event. If type is a PUT, it indicates
+  // If type is a PUT, it indicates that
   // new data has been stored to the key. If type is a DELETE,
   // it indicates the key was deleted.
   EventType type = 1;
@@ -258,8 +258,24 @@ message ChangeEvent {
   // A PUT event contains current value.
   // A DELETE event contains the deleted key with
   // its modification revision set to the revision of deletion.
-  ConfigFile value = 3;
+  File value = 3;
 
   // value before the operation was done. Optional.
-  ConfigFile prev_value = 4;
+  File prev_value = 4;
+}
+
+// DomainMap specifies how to compute the effective subdomain of a directory
+message DomainMap {
+  // asserted subdomains of this directory
+  // "/" is allowed to assert anything
+  // All other directories may only assert what is permitted by the parent.
+  repeated string self = 1;
+
+  // map a subdirectory to a set of permitted subdomains. 
+  map<string, Subdomains> mapping = 2; 
+
+}
+
+message Subdomains {
+  repeated string subdomains = 1;
 }

--- a/api/galley/v1/validation_error.proto
+++ b/api/galley/v1/validation_error.proto
@@ -1,0 +1,28 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+// If an update/delete to Galley fails
+// a ValidationError is contained in google.rpc.Status.details
+message ValidationError {
+  // The key of the object where error was detected.
+  // This may not be the object that introduced the error.
+  string key = 1;
+  // The primary field that was in error, if available.
+  string field = 2;
+  // Textual error message.
+  string error = 3;
+}

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -52,6 +52,9 @@ message ValidationRequest {
   // Supports multiple ordered changes to be validated together.
   // When a large config is pushed into Galley, batching
   // validation requests is an optimization.
+  // Validator has access to file.serverMetadata.Subdomains
+  // Validator must ensure that the configuration in the file
+  // only pertains to those subdomains.
   repeated ChangeEvent validations = 1;
 
   // Objects should be validated against this revision of the repository.
@@ -67,7 +70,7 @@ message ValidationResponse {
   google.rpc.Status status = 1; 
 
   // state of the file after transformation.
-  ConfigFile file = 2;
+  File file = 2;
 
   // errors if status = INVALID_ARGUMENT
   repeated ValidationError validation_errors = 3;

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -18,7 +18,8 @@ package istio.galley.v1;
 import "google/rpc/status.proto";
 import "google/api/annotations.proto";
 
-import "galley/v1/service.proto";
+import "api/galley/v1/config_object.proto";
+import "api/galley/v1/validation_error.proto";
 
 // ValidatorAndTransformer service validates objects before they are committed to storage.
 // Galley maintains a map of object_types to validators. A single validator may validate many types.
@@ -49,13 +50,10 @@ service ValidatorAndTransformer {
 };
 
 message ValidationRequest {
-  // Supports multiple ordered changes to be validated together.
-  // When a large config is pushed into Galley, batching
-  // validation requests is an optimization.
-  // Validator has access to file.serverMetadata.Subdomains
+  // Validator has access to file.scope.
   // Validator must ensure that the configuration in the file
-  // only pertains to those subdomains.
-  repeated ChangeEvent validations = 1;
+  // only pertains to its scope.
+  ConfigChange validation = 1;
 
   // Objects should be validated against this revision of the repository.
   // If the validator or the object is agnostic to repository versions, this can be ignored.
@@ -70,7 +68,7 @@ message ValidationResponse {
   google.rpc.Status status = 1; 
 
   // state of the file after transformation.
-  File file = 2;
+  ConfigFile file = 2;
 
   // errors if status = INVALID_ARGUMENT
   repeated ValidationError validation_errors = 3;

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -1,0 +1,74 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+import "google/rpc/status.proto";
+import "google/api/annotations.proto";
+
+import "galley/v1/service.proto";
+
+// ValidatorAndTransformer service validates objects before they are committed to storage.
+// Galley maintains a map of object_types to validators. A single validator may validate many types.
+// For example MixerValidator service should validate all Mixer resources.
+service ValidatorAndTransformer {
+  // Validate the resource and convert it to typed proto if applicable
+  // if Object.spec is specified, it should be converted to an appropriate proto representation.
+  // Every attempt should be made to do a deep validation.
+  // If full validation requires referential integrity checks, this service should use the
+  // GalleyWatch Service to maintain current view of the configuration.
+  //
+  // For example a Mixer rule consists of a selector expression and a named handler amongst other things. 
+  // Mixer validator should check 
+  // 1. expression syntax is valid
+  // 2. expression uses known attributes
+  // 3. Rule refers to a known handler
+  // 4. Any other semantic check that is required for full validation.
+  //
+  // It should convert the untyped proto into a typed proto and return binary encoding of it in Object.processed_spec.
+  // 
+  // On validation failure, it should return a validation error with text.
+  rpc ValidateAndTransform(ValidationRequest) returns (ValidationResponse) {
+    option (google.api.http) = {
+      post: "/resources/v1:validate"
+      body: "*"
+    };
+  };
+};
+
+message ValidationRequest {
+  // Supports multiple ordered changes to be validated together.
+  // When a large config is pushed into Galley, batching
+  // validation requests is an optimization.
+  repeated ChangeEvent validations = 1;
+
+  // Objects should be validated against this revision of the repository.
+  // If the validator or the object is agnostic to repository versions, this can be ignored.
+  // This is useful for referential integrity checking. 
+  int64 validation_revision = 2;
+}
+
+message ValidationResponse {
+  // result of the operation
+  // if status == INVALID_ARGUMENT
+  // check errors for details.
+  google.rpc.Status status = 1; 
+
+  // state of the file after transformation.
+  ConfigFile file = 2;
+
+  // errors if status = INVALID_ARGUMENT
+  repeated ValidationError validation_errors = 3;
+}

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -18,7 +18,7 @@ package istio.galley.v1;
 import "google/rpc/status.proto";
 import "google/api/annotations.proto";
 
-import "galley/v1/service.proto";
+import "api/galley/v1/config_object.proto";
 
 // Galley Watcher service is designed to efficiently watch mutiple subtrees of the resource tree.
 service Watcher { 
@@ -82,7 +82,7 @@ message WatchCreated {
 // WatchEvents indicates that this message contains events from the watch stream.
 message WatchEvents {
   // returns events for the specified watch id. 
-  repeated ChangeEvent events = 4;
+  repeated ConfigChange events = 4;
 }
 
 // WatchProgress message is sent periodically.
@@ -123,8 +123,14 @@ message WatchResponse {
   };
 };
 
+message ConfigFileKV {
+  string uid = 1;
+  ConfigFile file = 2;
+}
+
 message InitialState {
-  repeated ConfigEntry entries = 1;
+  
+  repeated ConfigFileKV entries = 1;
 
   // Last message from the initial state.
   // If done = true, watch events will start streaming next.

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -1,0 +1,132 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+import "google/rpc/status.proto";
+import "google/api/annotations.proto";
+
+import "galley/v1/service.proto";
+
+// Galley Watcher service is designed to efficiently watch mutiple subtrees of the resource tree.
+service Watcher { 
+  // Watch watches for events happening or that have happened. Both input and output
+  // are streams; the input stream is for creating and cancelling watchers and the output
+  // stream sends events. One watch RPC can watch on multiple key roots, streaming events
+  // for several watches at once. 
+  // The watch creation call will result in returning the current state of the subtree.
+  rpc Watch(stream WatchRequest) returns (stream WatchResponse) {
+    option (google.api.http) = {
+      post: "/events/v1:watch"
+      body: "*"
+    };
+  };
+};
+
+
+// WatchRequest creates on cancels a watch.
+// Create and cancel are part of the same message because the WatchRequest message
+// is used in a streaming API. The client may add new watchers and remove old watchers
+// on an existing stream.
+message WatchRequest {
+  // request_union indicates whether to create a new watcher or cancel an existing watcher.
+  oneof request_union {
+    WatchCreateRequest create_request = 1;
+    WatchCancelRequest cancel_request = 2;
+  }
+}
+
+message WatchCreateRequest {
+  // indicates the watched subtree.
+  string path = 1;
+
+  // config 'kinds' to watch.
+  repeated string kinds = 2;
+
+  // start watching from this revision of the repository.
+  // If the requested revision is not available, the watch request should fail.
+  // if not specified "now" is used.
+  int64 start_revision = 3;
+
+  // stream the inital state of the tree before sending updates.
+  bool include_initial_state = 4;
+}
+
+message WatchCancelRequest {
+  // watch_id is the watcher id to cancel so that no more events are transmitted.
+  int64 watch_id = 1;
+}
+
+// Indicates that watch was successfully canceled.
+message WatchCanceled {
+}
+
+// Indicates that a watch was successfully created.
+message WatchCreated {
+  // Revision of the repository when the initial state was produced.
+  int64 current_revision = 1;
+}
+
+// WatchEvents indicates that this message contains events from the watch stream.
+message WatchEvents {
+  // returns events for the specified watch id. 
+  repeated ChangeEvent events = 4;
+}
+
+// WatchProgress message is sent periodically.
+message WatchProgress {
+  // Revision of the repository when this event was sent.
+  int64 current_revision = 1;
+}
+
+
+message WatchResponse {
+  // watch_id is the ID of the watcher that corresponds to the response.
+  // watch_id does not apply to the unsolicited "Progress" message.
+  int64 watch_id = 1;
+
+  // if a watcher could not be created or had to be aborted status is NON-OK.
+  // client should not look at other fields if status is not OK and remove
+  // watch_id from the watch set.
+  google.rpc.Status status = 2;
+
+  oneof response_union {
+    // Watch was successfully created. Client should record the watch_id for this watch.
+    // If inital_state is requested, it will be streamed before the watch begins.
+    WatchCreated created = 3;
+
+    // Initial state when the watch begins.
+    InitialState initial_state = 4;
+
+    // response contains events from a watched subtree.
+    WatchEvents events = 5;
+    
+    // a previous watch was successfully canceled.
+    // No further events will be sent to the canceled watcher.
+    WatchCanceled canceled = 6; 
+
+    // Server sends periodic messages of progress when no actual watches fire.
+    // The client knows it is caught up to a certain revision of the repository.
+    WatchProgress progress = 7; 
+  };
+};
+
+message InitialState {
+  repeated ConfigEntry entries = 1;
+
+  // Last message from the initial state.
+  // If done = true, watch events will start streaming next.
+  bool done = 4;
+}

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -52,8 +52,8 @@ message WatchCreateRequest {
   // indicates the watched subtree.
   string path = 1;
 
-  // config 'kinds' to watch.
-  repeated string kinds = 2;
+  // config 'types' to watch.
+  repeated string types = 2;
 
   // start watching from this revision of the repository.
   // If the requested revision is not available, the watch request should fail.


### PR DESCRIPTION
Based on https://github.com/istio/api/pull/122
Moving it in the Galley repo until API is stable, at which point we will move it back to istio/api.
[Design doc](https://docs.google.com/document/d/1b6T8Xigrc2uN8x9npl6os43N-MhnlnAbNAJZMKUVEMQ/edit)

1. Hierarchical config model
2. Watcher API streams initial_state, similar to change events.
3. revisions are used for optimistic concurrency and watch efficiency. 

Versioning will follow in a separate design doc and a PR.
