### PR TITLE
remove warning messages on bin/linters.sh

### DIFF
--- a/BUILD.ubuntu
+++ b/BUILD.ubuntu
@@ -1,6 +1,6 @@
 # build base docker ubuntu image
 
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 docker_build(
     name = "xenial",

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -68,6 +68,7 @@ go_metalinter() {
     if [[ -z ${PKGS[@]} ]]; then
         echo 'No packages set'
     else
+        # updated to avoid WARNING: staticcheck, gosimple, and unused are all set, using megacheck instead
         gometalinter\
           --concurrency=4\
           --enable-gc\
@@ -81,15 +82,13 @@ go_metalinter() {
           --enable=gofmt\
           --enable=goimports\
           --enable=golint --min-confidence=0 --exclude=.pb.go --exclude=pkg/config/proto/combined.go --exclude="should have a package comment"\
-          --enable=gosimple\
           --enable=ineffassign\
           --enable=interfacer\
           --enable=lll --line-length=160\
+          --enable=megacheck \
           --enable=misspell\
-          --enable=staticcheck\
           --enable=structcheck\
           --enable=unconvert\
-          --enable=unused\
           --enable=varcheck\
           --enable=vet\
           --enable=vetshadow\


### PR DESCRIPTION
- use megacheck instead of gosimple/staticcheck/unused
  Same as
  https://github.com/istio/istio/commit/551226382dbf84c509b0f08ece573e32c9dcc3c5#diff-a45186e4c525a7b8a78dcdbef0c30ede,
- stop using bazel_tools//tools/build_defs/docker:docker.bzl
  since it's deprecated