### PR TITLE
fix the WORKSPACE entry for rules_protobuf

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,8 +12,8 @@ go_repositories()
 
 git_repository(
     name = "org_pubref_rules_protobuf",
-    commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31 2017 (gogo* support)
-    remote = "https://github.com/geeknoid/rules_protobuf",
+    commit = "9ede1dbc38f0b89ae6cd8e206a22dd93cc1d5637",  # Mar 31, 2017 (gogo* support)
+    remote = "https://github.com/pubref/rules_protobuf",
 )
 
 load("@org_pubref_rules_protobuf//protobuf:rules.bzl", "proto_repositories")


### PR DESCRIPTION
github.com/geeknoid/rules_protobuf repository does not exist
anymore, using pubref/rules_protobuf is fine.