### PR TITLE
Galley API: Change File.content from bytes to string

### DIFF
--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -157,7 +157,7 @@ message DeleteFileRequest{
 message File{
   string path = 1;
 
-  // Contents are modified by Galley. A roundtrip may not yeild the same results.
+  // Contents are modified by Galley. A roundtrip may not yeild the same result.
   string contents = 2;
 
   // client supplied metadata.

--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -93,7 +93,7 @@ enum ContentType{
 message CreateFileRequest {
   string path = 1;
 
-  bytes contents = 2;
+  string contents = 2;
 
   ContentType content_type = 3;
 
@@ -104,7 +104,7 @@ message CreateFileRequest {
 message UpdateFileRequest {
   string path = 1;
 
-  bytes contents = 2;
+  string contents = 2;
 
   ContentType content_type = 3;
 
@@ -158,7 +158,7 @@ message File{
   string path = 1;
 
   // Contents are modified by Galley. A roundtrip may not yeild the same results.
-  bytes contents = 2;
+  string contents = 2;
 
   // client supplied metadata.
   Metadata metadata = 3;


### PR DESCRIPTION
Configuration files are expected to be text files.
String represents that better than bytes.

If contents are `bytes` they are encoded as base64 in the json representation. 