### PR TITLE
Galley watcher and validator APIs

### DIFF
--- a/api/galley/v1/config_object.proto
+++ b/api/galley/v1/config_object.proto
@@ -81,7 +81,7 @@ message ConfigObject {
   // For example: route-rule corresponds to istio.proxy.v1.config.RouteRule.
   // schema_id is returned by the Validator / Transformer and it is stored with the object.
   // If a proto changes in a backwards incompatible way, it must get a new schema_id.
-  // Schema_id may contain sematic version information.
+  // Schema_id may contain semantic version information.
   string schema_id = 6;
 }
 

--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -152,6 +152,10 @@ message GetFileRequest{
 message DeleteFileRequest{
   // path of the config file from root.
   string path = 1; 
+
+  // Revision is used to avoid blind writes.
+  // The default (revision == 0) means allow blind writes.
+  int64 revision = 2;
 }
 
 // A view of configuration file stored at a location.

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -1,0 +1,113 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+import "google/api/annotations.proto";
+import "google/rpc/status.proto";
+
+import "api/galley/v1/config_object.proto";
+
+// ValidatorAndTransformer service validates objects before they are committed to storage.
+// Galley maintains the mapping state from object types to validators using a grpc stream. 
+// A single validator may validate many types.
+// For example MixerValidator service should validate all Mixer resources.
+service ValidatorAndTransformer {
+
+  // Validate the resource and convert it to typed proto if applicable
+  // Object.spec should be converted to an appropriate proto representation.
+  // Every attempt should be made to do a deep validation.
+  // If full validation requires referential integrity checks, this service should use the
+  // GalleyWatch Service to maintain current view of the configuration.
+  //
+  // For example a Mixer rule consists of a selector expression and a named handler amongst other things. 
+  // Mixer validator should check 
+  // 1. expression syntax is valid
+  // 2. expression uses known attributes
+  // 3. Rule refers to a known handler
+  // 4. Any other semantic check that is required for full validation.
+  //
+  // It should convert the untyped proto into a typed proto and return 
+  // binary encoding of it in ConfigObject.processed_spec. It should also set
+  // [ConfigObject.schema_id] appropriately.
+  // 
+  // On validation failure google.rpc.Status.details contains reasons for the failure as [ValidationError]s.
+  rpc ValidateAndTransform(stream ValidationRequest) returns (stream ValidationResponse) {
+    option (google.api.http) = {
+      post: "/resources/v1:validate"
+      body: "*"
+    };
+  };
+};
+
+// ValidationRequest is the top level request message for the grpc service.
+message ValidationRequest {
+  oneof request_union {
+    // Request for information about the validator such as the types it can validate.
+    ValidatorInfoRequest info_request = 1;
+
+    // A validation request.
+    ValidateConfigRequest validate_request = 2;
+  }
+}
+
+// ValidationResponse is the top level response message for the grpc service.
+message ValidationResponse {
+  oneof response_union {
+    // Information about the validator such as the types it can validate.
+    ValidatorInfoResponse info_response = 1;
+
+    // A validation response.
+    ValidateConfigResponse validate_response = 2;
+  } 
+}
+
+// ValidatorInfoRequest seeks information about the validator.
+// The first request Galley sends to the validator after the stream is established
+// must be an info request. Validator must respond with object types it can validate.
+message ValidatorInfoRequest {
+}
+
+// ValidatorInfoResponse is the reply to ValidatorInfoRequest.
+// There must be exactly one response to the info request.
+message ValidatorInfoResponse {
+
+  // Name of the validator.
+  // Example: MixerValidator, PilotValidator, ...
+  string name = 1;
+
+  // "Types" specify the object types that the validator can validate.
+  repeated string types = 2;
+}
+
+// ValidateConfigRequest is the streaming request for config validation.
+message ValidateConfigRequest {
+  // Validator must ensure that the configuration in the file
+  // only pertains to file.scope.
+  ConfigFileChange validation = 1;
+
+  // Objects should be validated against this revision of the repository.
+  // If the validator or the object is agnostic to repository versions, this can be ignored.
+  // This is useful for referential integrity checking. 
+  int64 validation_revision = 2;
+}
+
+message ValidateConfigResponse {
+  // state of the file after transformation.
+  ConfigFile file = 1;
+
+  // If validation fails status.details contains reasons for the failure as [ValidationError]s.
+  google.rpc.Status status = 2;
+}

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -29,7 +29,7 @@ import "api/galley/v1/config_object.proto";
 //
 // Galley collects responses from all validators and
 // 1. Signals UnkownType error if a ConfigObject type was left unvalidated.
-// 2. Signals error if validators validated the same object in conflicting ways.
+// 2. Signals error if validators transformed the same object in conflicting ways.
 // 3. On a successful merge, Galley commits the [ConfigFile] to storage.
 //
 // The ValidatorAndTransformer service does the following.

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -19,12 +19,12 @@ import "google/api/annotations.proto";
 
 import "api/galley/v1/config_object.proto";
 
-// ValidatorAndTransformer service.
+// TransformerAndValidator service.
 //
-// Galley uses the ValidatorAndTransformer service to validate and transform incoming
+// Galley uses the TransformerAndValidator service to transform and validate incoming
 // configuration changes. Galley knows about a set of validator services through configuration.
 // On an incoming config change, Galley broadcasts the change to all available validators.
-// A validator must validate and transform all ConfigObject types it can process.
+// A validator must transform and validate all ConfigObject types it can process.
 // A validator must not modify other ConfigObjects in the ConfigFile.
 //
 // Galley collects responses from all validators and
@@ -32,14 +32,14 @@ import "api/galley/v1/config_object.proto";
 // 2. Signals error if validators transformed the same object in conflicting ways.
 // 3. On a successful merge, Galley commits the [ConfigFile] to storage.
 //
-// The ValidatorAndTransformer service does the following.
+// The TransformerAndValidator service does the following.
 // 1. Validates [ConfigObject] types before they are committed to storage.
 // 2. Trasforms [ConfigObject.spec] into [ConfigObject.processed_spec]
 // A single validator may validate many types.
 // For example MixerValidator service may validate all Mixer resources.
-service ValidatorAndTransformer {
+service TransformerAndValidator {
 
-  // ValidateAndTransform ConfigFile.
+  // TransformAndValidate ConfigFile.
   //
   // Every attempt should be made to do a deep validation.
   // If full validation requires referential integrity checks, this service should use the
@@ -57,7 +57,7 @@ service ValidatorAndTransformer {
   // It should also set [ConfigObject.schema_id] appropriately. Check [ConfigObject.schema_id] for details.
   // 
   // On validation failure google.rpc.Status.details contains reasons for the failure as [ValidationError]s.
-  rpc ValidateAndTransform(ValidationRequest) returns (ValidationResponse) {
+  rpc TransformAndValidate(ValidationRequest) returns (ValidationResponse) {
     option (google.api.http) = {
       post: "/resources/v1:validate"
       body: "*"

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -65,12 +65,14 @@ message ValidationRequest {
 
 // ValidationResponse is the top level response message for the grpc service.
 message ValidationResponse {
+  // If validation fails status.details contains reasons for the failure as [ValidationError]s.
+  google.rpc.Status status = 1;
   oneof response_union {
     // Information about the validator such as the types it can validate.
-    ValidatorInfoResponse info_response = 1;
+    ValidatorInfoResponse info_response = 2;
 
     // A validation response.
-    ValidateConfigResponse validate_response = 2;
+    ValidateConfigResponse validate_response = 3;
   } 
 }
 
@@ -108,6 +110,4 @@ message ValidateConfigResponse {
   // state of the file after transformation.
   ConfigFile file = 1;
 
-  // If validation fails status.details contains reasons for the failure as [ValidationError]s.
-  google.rpc.Status status = 2;
 }

--- a/api/galley/v1/validator.proto
+++ b/api/galley/v1/validator.proto
@@ -16,18 +16,31 @@ syntax = "proto3";
 package istio.galley.v1;
 
 import "google/api/annotations.proto";
-import "google/rpc/status.proto";
 
 import "api/galley/v1/config_object.proto";
 
-// ValidatorAndTransformer service validates objects before they are committed to storage.
-// Galley maintains the mapping state from object types to validators using a grpc stream. 
+// ValidatorAndTransformer service.
+//
+// Galley uses the ValidatorAndTransformer service to validate and transform incoming
+// configuration changes. Galley knows about a set of validator services through configuration.
+// On an incoming config change, Galley broadcasts the change to all available validators.
+// A validator must validate and transform all ConfigObject types it can process.
+// A validator must not modify other ConfigObjects in the ConfigFile.
+//
+// Galley collects responses from all validators and
+// 1. Signals UnkownType error if a ConfigObject type was left unvalidated.
+// 2. Signals error if validators validated the same object in conflicting ways.
+// 3. On a successful merge, Galley commits the [ConfigFile] to storage.
+//
+// The ValidatorAndTransformer service does the following.
+// 1. Validates [ConfigObject] types before they are committed to storage.
+// 2. Trasforms [ConfigObject.spec] into [ConfigObject.processed_spec]
 // A single validator may validate many types.
-// For example MixerValidator service should validate all Mixer resources.
+// For example MixerValidator service may validate all Mixer resources.
 service ValidatorAndTransformer {
 
-  // Validate the resource and convert it to typed proto if applicable
-  // Object.spec should be converted to an appropriate proto representation.
+  // ValidateAndTransform ConfigFile.
+  //
   // Every attempt should be made to do a deep validation.
   // If full validation requires referential integrity checks, this service should use the
   // GalleyWatch Service to maintain current view of the configuration.
@@ -39,12 +52,12 @@ service ValidatorAndTransformer {
   // 3. Rule refers to a known handler
   // 4. Any other semantic check that is required for full validation.
   //
-  // It should convert the untyped proto into a typed proto and return 
-  // binary encoding of it in ConfigObject.processed_spec. It should also set
-  // [ConfigObject.schema_id] appropriately.
+  // It should convert the untyped proto [ConfigObject.spec] into a typed proto
+  // and return binary encoding of it in ConfigObject.processed_spec.
+  // It should also set [ConfigObject.schema_id] appropriately. Check [ConfigObject.schema_id] for details.
   // 
   // On validation failure google.rpc.Status.details contains reasons for the failure as [ValidationError]s.
-  rpc ValidateAndTransform(stream ValidationRequest) returns (stream ValidationResponse) {
+  rpc ValidateAndTransform(ValidationRequest) returns (ValidationResponse) {
     option (google.api.http) = {
       post: "/resources/v1:validate"
       body: "*"
@@ -52,62 +65,19 @@ service ValidatorAndTransformer {
   };
 };
 
-// ValidationRequest is the top level request message for the grpc service.
+// ValidationRequest is the request for config validation.
 message ValidationRequest {
-  oneof request_union {
-    // Request for information about the validator such as the types it can validate.
-    ValidatorInfoRequest info_request = 1;
-
-    // A validation request.
-    ValidateConfigRequest validate_request = 2;
-  }
-}
-
-// ValidationResponse is the top level response message for the grpc service.
-message ValidationResponse {
-  // If validation fails status.details contains reasons for the failure as [ValidationError]s.
-  google.rpc.Status status = 1;
-  oneof response_union {
-    // Information about the validator such as the types it can validate.
-    ValidatorInfoResponse info_response = 2;
-
-    // A validation response.
-    ValidateConfigResponse validate_response = 3;
-  } 
-}
-
-// ValidatorInfoRequest seeks information about the validator.
-// The first request Galley sends to the validator after the stream is established
-// must be an info request. Validator must respond with object types it can validate.
-message ValidatorInfoRequest {
-}
-
-// ValidatorInfoResponse is the reply to ValidatorInfoRequest.
-// There must be exactly one response to the info request.
-message ValidatorInfoResponse {
-
-  // Name of the validator.
-  // Example: MixerValidator, PilotValidator, ...
-  string name = 1;
-
-  // "Types" specify the object types that the validator can validate.
-  repeated string types = 2;
-}
-
-// ValidateConfigRequest is the streaming request for config validation.
-message ValidateConfigRequest {
-  // Validator must ensure that the configuration in the file
-  // only pertains to file.scope.
+  // Validator must ensure that the configuration in the file does not
+  // exceed ConfigFile.scope.
   ConfigFileChange validation = 1;
 
   // Objects should be validated against this revision of the repository.
-  // If the validator or the object is agnostic to repository versions, this can be ignored.
-  // This is useful for referential integrity checking. 
+  // Stateless validators may ignore this field.
+  // For example, validation_revision is useful for referential integrity checks. 
   int64 validation_revision = 2;
 }
 
-message ValidateConfigResponse {
+message ValidationResponse {
   // state of the file after transformation.
   ConfigFile file = 1;
-
 }

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -24,7 +24,8 @@ import "api/galley/v1/config_object.proto";
 service Watcher {
   // Watch watches for events occurring in Galley.
   // A watch is created by creating a watch stream.
-  // The stream begins with the current state of the subtree.
+  // The stream may begin with the current state of the subtree
+  // if include_initial_state=true.
   rpc Watch(WatchRequest) returns (stream WatchResponse) {
     option (google.api.http) = {
       post: "/events/v1:watch"

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -20,15 +20,12 @@ import "google/api/annotations.proto";
 
 import "api/galley/v1/config_object.proto";
 
-// Galley Watcher service is designed to efficiently watch mutiple subtrees of the resource tree.
+// Galley Watcher service is designed for clients to efficiently watch resource subtrees.
 service Watcher {
-
-  // Watch watches for events happening or that have happened. Both input and output
-  // are streams; the input stream is for creating and cancelling watchers and the output
-  // stream sends events. One watch RPC can watch on multiple key roots, streaming events
-  // for several watches at once. 
-  // The watch creation call will result in returning the current state of the subtree.
-  rpc Watch(stream WatchRequest) returns (stream WatchResponse) {
+  // Watch watches for events occurring in Galley.
+  // A watch is created by creating a watch stream.
+  // The stream begins with the current state of the subtree.
+  rpc Watch(WatchRequest) returns (stream WatchResponse) {
     option (google.api.http) = {
       post: "/events/v1:watch"
       body: "*"
@@ -36,21 +33,9 @@ service Watcher {
   };
 };
 
-
-// WatchRequest creates on cancels a watch.
-// Create and cancel are part of the same message because the WatchRequest message
-// is used in a streaming API. The client may add new watchers and remove old watchers
-// on an existing stream.
+// WatchRequest creates a watch stream.
 message WatchRequest {
-  // request_union indicates whether to create a new watcher or cancel an existing watcher.
-  oneof request_union {
-    WatchCreateRequest create_request = 1;
-    WatchCancelRequest cancel_request = 2;
-  }
-}
-
-message WatchCreateRequest {
-  // Scope denotes the watched subtree, empty scope means watch the entire tree.
+  // Scope denotes the watched subtree, empty scope denotes the entire tree.
   string scope = 1;
 
   // config 'types' to watch.
@@ -65,19 +50,43 @@ message WatchCreateRequest {
   bool include_initial_state = 4;
 }
 
-message WatchCancelRequest {
-  // watch_id is the watcher id to cancel so that no more events are transmitted.
-  int64 watch_id = 1;
-}
+// WatchResponse message on the response stream.
+message WatchResponse {
+  // if a watcher could not be created or had to be aborted status is NON-OK.
+  // client should not look at other fields if status is not OK.
+  google.rpc.Status status = 1;
 
-// Indicates that watch was successfully canceled.
-message WatchCanceled {
-}
+  oneof response_union {
+    // Watch was successfully created.
+    WatchCreated created = 2;
+
+    // Initial state when the watch begins.
+    InitialState initial_state = 3;
+
+    // response contains events from a watched subtree.
+    WatchEvents events = 4;
+    
+    // Server sends periodic messages of progress even when no watches fire.
+    // The client knows it is caught up to a certain revision of the repository.
+    WatchProgress progress = 5; 
+  };
+};
 
 // Indicates that a watch was successfully created.
 message WatchCreated {
   // Revision of the repository when the initial state was produced.
   int64 current_revision = 1;
+}
+
+// IntialState is the state of the config subtree when watch begins.
+message InitialState {
+  // Entries in the initial state.
+  // A large initial state may be broken up into multiple messages.  
+  repeated ConfigFileEntry entries = 1;
+
+  // Last message from the initial state.
+  // If done == true, watch events will start streaming next.
+  bool done = 4;
 }
 
 // WatchEvents indicates that this message contains events from the watch stream.
@@ -90,49 +99,6 @@ message WatchEvents {
 message WatchProgress {
   // Revision of the repository when this event was sent.
   int64 current_revision = 1;
-}
-
-
-message WatchResponse {
-  // watch_id is the ID of the watcher that corresponds to the response.
-  // watch_id does not apply to the unsolicited "Progress" message.
-  int64 watch_id = 1;
-
-  // if a watcher could not be created or had to be aborted status is NON-OK.
-  // client should not look at other fields if status is not OK and remove
-  // watch_id from the watch set.
-  google.rpc.Status status = 2;
-
-  oneof response_union {
-    // Watch was successfully created. Client should record the watch_id for this watch.
-    // If inital_state is requested, it will be streamed before the watch begins.
-    WatchCreated created = 3;
-
-    // Initial state when the watch begins.
-    InitialState initial_state = 4;
-
-    // response contains events from a watched subtree.
-    WatchEvents events = 5;
-    
-    // a previous watch was successfully canceled.
-    // No further events will be sent to the canceled watcher.
-    WatchCanceled canceled = 6; 
-
-    // Server sends periodic messages of progress when no actual watches fire.
-    // The client knows it is caught up to a certain revision of the repository.
-    WatchProgress progress = 7; 
-  };
-};
-
-// IntialState is the state of the config subtree when watch begins.
-message InitialState {
-  // Entries in the initial state.
-  // A large initial state may be broken up into multiple messages.  
-  repeated ConfigFileEntry entries = 1;
-
-  // Last message from the initial state.
-  // If done == true, watch events will start streaming next.
-  bool done = 4;
 }
 
 message ConfigFileEntry {

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -1,0 +1,145 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.v1;
+
+import "google/rpc/status.proto";
+import "google/api/annotations.proto";
+
+import "api/galley/v1/config_object.proto";
+
+// Galley Watcher service is designed to efficiently watch mutiple subtrees of the resource tree.
+service Watcher {
+
+  // Watch watches for events happening or that have happened. Both input and output
+  // are streams; the input stream is for creating and cancelling watchers and the output
+  // stream sends events. One watch RPC can watch on multiple key roots, streaming events
+  // for several watches at once. 
+  // The watch creation call will result in returning the current state of the subtree.
+  rpc Watch(stream WatchRequest) returns (stream WatchResponse) {
+    option (google.api.http) = {
+      post: "/events/v1:watch"
+      body: "*"
+    };
+  };
+};
+
+
+// WatchRequest creates on cancels a watch.
+// Create and cancel are part of the same message because the WatchRequest message
+// is used in a streaming API. The client may add new watchers and remove old watchers
+// on an existing stream.
+message WatchRequest {
+  // request_union indicates whether to create a new watcher or cancel an existing watcher.
+  oneof request_union {
+    WatchCreateRequest create_request = 1;
+    WatchCancelRequest cancel_request = 2;
+  }
+}
+
+message WatchCreateRequest {
+  // Scope denotes the watched subtree, empty scope means watch the entire tree.
+  string scope = 1;
+
+  // config 'types' to watch.
+  repeated string types = 2;
+
+  // start watching from this revision of the repository.
+  // If the requested revision is not available, the watch request should fail.
+  // if not specified "now" is used.
+  int64 start_revision = 3;
+
+  // stream the inital state of the tree before sending updates.
+  bool include_initial_state = 4;
+}
+
+message WatchCancelRequest {
+  // watch_id is the watcher id to cancel so that no more events are transmitted.
+  int64 watch_id = 1;
+}
+
+// Indicates that watch was successfully canceled.
+message WatchCanceled {
+}
+
+// Indicates that a watch was successfully created.
+message WatchCreated {
+  // Revision of the repository when the initial state was produced.
+  int64 current_revision = 1;
+}
+
+// WatchEvents indicates that this message contains events from the watch stream.
+message WatchEvents {
+  // returns events for the specified watch id. 
+  repeated ConfigFileChange events = 4;
+}
+
+// WatchProgress message is sent periodically.
+message WatchProgress {
+  // Revision of the repository when this event was sent.
+  int64 current_revision = 1;
+}
+
+
+message WatchResponse {
+  // watch_id is the ID of the watcher that corresponds to the response.
+  // watch_id does not apply to the unsolicited "Progress" message.
+  int64 watch_id = 1;
+
+  // if a watcher could not be created or had to be aborted status is NON-OK.
+  // client should not look at other fields if status is not OK and remove
+  // watch_id from the watch set.
+  google.rpc.Status status = 2;
+
+  oneof response_union {
+    // Watch was successfully created. Client should record the watch_id for this watch.
+    // If inital_state is requested, it will be streamed before the watch begins.
+    WatchCreated created = 3;
+
+    // Initial state when the watch begins.
+    InitialState initial_state = 4;
+
+    // response contains events from a watched subtree.
+    WatchEvents events = 5;
+    
+    // a previous watch was successfully canceled.
+    // No further events will be sent to the canceled watcher.
+    WatchCanceled canceled = 6; 
+
+    // Server sends periodic messages of progress when no actual watches fire.
+    // The client knows it is caught up to a certain revision of the repository.
+    WatchProgress progress = 7; 
+  };
+};
+
+// IntialState is the state of the config subtree when watch begins.
+message InitialState {
+  // Entries in the initial state.
+  // A large initial state may be broken up into multiple messages.  
+  repeated ConfigFileKV entries = 1;
+
+  // Last message from the initial state.
+  // If done == true, watch events will start streaming next.
+  bool done = 4;
+}
+
+message ConfigFileKV {
+  // File_id is a unique Id associated with the config file.
+  // Watcher should retain file_id so that it can be matched against
+  // ConfigFileChange events.
+  string file_id = 1;
+
+  ConfigFile file = 2;
+}

--- a/api/galley/v1/watcher.proto
+++ b/api/galley/v1/watcher.proto
@@ -128,14 +128,14 @@ message WatchResponse {
 message InitialState {
   // Entries in the initial state.
   // A large initial state may be broken up into multiple messages.  
-  repeated ConfigFileKV entries = 1;
+  repeated ConfigFileEntry entries = 1;
 
   // Last message from the initial state.
   // If done == true, watch events will start streaming next.
   bool done = 4;
 }
 
-message ConfigFileKV {
+message ConfigFileEntry {
   // File_id is a unique Id associated with the config file.
   // Watcher should retain file_id so that it can be matched against
   // ConfigFileChange events.


### PR DESCRIPTION
* Watcher API. Unidirectional Streaming API.
1. A watcher subscribes to a `scope` and a list of types. 
2. The initial state of the tree is optionally streamed to the client before the watch begins.

Watcher processes connect to Galley WatchServer.

* Validator API. Unary API.
Galley is configured with a list of validators.
Galley broadcasts a change to all available validators.
** A validator must validate and transform all ConfigObject types it can process.
** A validator must not modify other ConfigObjects in the ConfigFile.