### PR TITLE
allow configStoreURL memory://

### DIFF
--- a/pkg/store/inventory/BUILD
+++ b/pkg/store/inventory/BUILD
@@ -9,5 +9,6 @@ go_library(
     deps = [
         "//pkg/store:go_default_library",
         "//pkg/store/etcd:go_default_library",
+        "//pkg/store/memstore:go_default_library",
     ],
 )

--- a/pkg/store/inventory/inventory.go
+++ b/pkg/store/inventory/inventory.go
@@ -17,11 +17,13 @@ package inventory
 import (
 	"istio.io/galley/pkg/store"
 	"istio.io/galley/pkg/store/etcd"
+	"istio.io/galley/pkg/store/memstore"
 )
 
 // NewInventory returns the default set of register functions.
 func NewInventory() []store.RegisterFunc {
 	return []store.RegisterFunc{
 		etcd.Register,
+		memstore.Register,
 	}
 }

--- a/pkg/store/memstore/memstore.go
+++ b/pkg/store/memstore/memstore.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -106,5 +107,12 @@ func New() *Store {
 	return &Store{
 		data:     map[string][]byte{},
 		revision: 0,
+	}
+}
+
+// Register registers memory scheme as the store backend.
+func Register(m map[string]store.Builder) {
+	m["memory"] = func(u *url.URL) (store.Store, error) {
+		return New(), nil
 	}
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -46,7 +46,7 @@ type Store interface {
 
 // ErrNotFound is an error which can be used to express that the underlying
 // storage works well but simply the value is missing.
-var ErrNotFound error = fmt.Errorf("not found")
+var ErrNotFound = fmt.Errorf("not found")
 
 // RevisionMismatchError should be returned on Set method when the
 // specified revision doesn't satisfy the expectation.


### PR DESCRIPTION
This allows specifying memory:// for on-memory storage (memstore)
for the config store URL. I don't think this will be used in poduction,
but this would simplify the environment for e2e tests with Galley.