### PR TITLE
Include the original file contents in {Create,Update}FileRequest

### DIFF
--- a/api/galley/v1/service.proto
+++ b/api/galley/v1/service.proto
@@ -54,7 +54,7 @@ service Galley {
 
   // List config files.
   // A note on http mapping.
-  // google.api.http permits the multi segment match '**' operator as the last match only, 
+  // google.api.http permits the multi segment match '**' operator as the last match only,
   // except when :VERB is used. Here we use :list verb to disambiguate between
   // GET on a file and GET on a directory.
   rpc ListFiles(ListFilesRequest) returns (ListFilesResponse) {
@@ -85,7 +85,7 @@ service Galley {
 }
 
 // content type of a file when it is sent by the client.
-enum ContentType{
+enum ContentType {
   UNKNOWN = 0;
   JSON = 1;
   YAML = 2;
@@ -93,24 +93,42 @@ enum ContentType{
 }
 
 message CreateFileRequest {
+  // Path of the user configuration file. This takes precedence over
+  // the path encoded in istio.galley.v1.File::contents.
   string path = 1;
 
+  // The original file contents of the user configuration as defined
+  // by [File][istio.galley.v1.File]. This should reflect the
+  // unmodified input source file as originally specified by the
+  // user. Clients may decode the file content to extract specific
+  // fields, e.g. istio.galley.v1.file::path, but should not persist
+  // the re-encoded version in the request's `content` field.
   string contents = 2;
 
   ContentType content_type = 3;
 
-  // client supplied metadata.
+  // Client supplied metadata. This takes precedence over the metadata
+  // encoded in istio.galley.v1.File::contents.
   Metadata metadata = 4;
 }
 
 message UpdateFileRequest {
+  // Path of the user configuration file. This takes precedence over
+  // the path encoded in istio.galley.v1.File::contents.
   string path = 1;
 
+  // The original file contents of the user configuration as defined
+  // by [File][istio.galley.v1.File]. This should reflect the
+  // unmodified input source file as originally specified by the
+  // user. Clients may decode the file content to extract specific
+  // fields, e.g. istio.galley.v1.file::path, but should not persist
+  // the re-encoded version in the request's `content` field.
   string contents = 2;
 
   ContentType content_type = 3;
 
-  // client supplied metadata.
+  // Client supplied metadata. This takes precedence over the metadata
+  // encoded in istio.galley.v1.File::contents.
   Metadata metadata = 4;
 
   // Revision is used to avoid blind writes.
@@ -118,7 +136,7 @@ message UpdateFileRequest {
   int64 revision = 5;
 }
 
-message ListFilesResponse{
+message ListFilesResponse {
   // if include_contents is specified, this includes file contents.
   repeated File entries = 1;
 
@@ -127,11 +145,11 @@ message ListFilesResponse{
   string next_page_token = 2;
 }
 
-message ListFilesRequest{
+message ListFilesRequest {
   // Path of the directory from root.
   string path = 1;
 
-  // Recurse thru the directory hierarchy. 
+  // Recurse thru the directory hierarchy.
   bool recurse = 2;
 
   // Include [File][istio.galley.v1.File] contents along with paths.
@@ -144,14 +162,14 @@ message ListFilesRequest{
   int32 max_page_size = 5;
 }
 
-message GetFileRequest{
-  // path of the config file from root.
-  string path = 1; 
+message GetFileRequest {
+ // path of the config file from root.
+  string path = 1;
 }
 
-message DeleteFileRequest{
+message DeleteFileRequest {
   // path of the config file from root.
-  string path = 1; 
+  string path = 1;
 
   // Revision is used to avoid blind writes.
   // The default (revision == 0) means allow blind writes.
@@ -160,10 +178,12 @@ message DeleteFileRequest{
 
 // A view of configuration file stored at a location.
 // A file must have a *.cfg extension.
-message File{
+message File {
   string path = 1;
 
-  // Contents are modified by Galley. A roundtrip may not yeild the same result.
+  // Configuration file contents as defined by
+  // istio.galley.v1.ConfigFile. The contents of this file may be
+  // modified by Galley. A roundtrip may not yeild the same result.
   string contents = 2;
 
   // client supplied metadata.

--- a/bin/gazelle
+++ b/bin/gazelle
@@ -14,3 +14,7 @@ fi
 gazelle \
     -go_prefix istio.io/galley \
     -build_file_name BUILD
+
+find . -type f -name BUILD -print0 | \
+    xargs -0 sed -i \
+          -e '/\/\/api\/galley\/v1:go_default_library/d'

--- a/pkg/server/BUILD
+++ b/pkg/server/BUILD
@@ -12,9 +12,10 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//api:galley/v1",
+        "//api:galley/v1",  # keep
         "//pkg/store:go_default_library",
         "//pkg/store/inventory:go_default_library",
+        "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
@@ -36,7 +37,7 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//api:galley/v1",
+        "//api:galley/v1",  # keep
         "//pkg/store/memstore:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -63,7 +63,8 @@ func (s *GalleyService) ListFiles(ctx context.Context, req *galleypb.ListFilesRe
 	return &galleypb.ListFilesResponse{Entries: entries}, nil
 }
 
-func (s *GalleyService) createOrUpdate(ctx context.Context, path, fileContents string, metadata *galleypb.Metadata, ctype galleypb.ContentType) (*galleypb.File, error) {
+func (s *GalleyService) createOrUpdate(ctx context.Context, path, fileContents string, metadata *galleypb.Metadata,
+	ctype galleypb.ContentType) (*galleypb.File, error) {
 	// Extract the original configuration file contents and merge with
 	// the user specified path and metadata.
 	//

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -211,7 +211,7 @@ func TestCRUD(t *testing.T) {
 	if file.Path != p1 {
 		t.Fatalf("Wrong path: Got %v\nWant %v", file.Path, p1)
 	}
-	if err := diffContent(file.Contents, testConfig); err != nil {
+	if err = diffContent(file.Contents, testConfig); err != nil {
 		t.Fatalf("GetFile(%v) wrong file contents: %v", p1, err)
 	}
 	path, ok := header["file-path"]
@@ -254,7 +254,7 @@ func TestCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get the file %s: %v", p2, err)
 	}
-	if err := diffContent(file.Contents, string(jsonData)); err != nil {
+	if err = diffContent(file.Contents, string(jsonData)); err != nil {
 		t.Fatalf("GetFile(%v) wrong file contents: %v", p2, err)
 	}
 	resp, err = tm.client.ListFiles(ctx, &galleypb.ListFilesRequest{Path: "/dept1", IncludeContents: true})
@@ -267,7 +267,7 @@ func TestCRUD(t *testing.T) {
 	if resp.Entries[0].Path != p1 {
 		t.Fatalf("ListFiles(/depth) returned wrong path: got %v want %v", resp.Entries[0].Path, p1)
 	}
-	if err := diffContent(resp.Entries[0].Contents, testConfig); err != nil {
+	if err = diffContent(resp.Entries[0].Contents, testConfig); err != nil {
 		t.Fatalf("ListFiles(/dept) wrong file contents: %v", err)
 	}
 	_, err = tm.client.DeleteFile(ctx, &galleypb.DeleteFileRequest{Path: p1})

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -165,7 +165,7 @@ func diffContent(gotConfigContents, wantFile string) error {
 	if err := yaml.Unmarshal([]byte(wantFile), &want); err != nil {
 		return fmt.Errorf("Error unmarshalling desired file contents `want`: %v", err)
 	}
-	if !reflect.DeepEqual(gotConfig, want["contents"]) {
+	if !reflect.DeepEqual(got, want["contents"]) {
 		return fmt.Errorf("Wrong YAML file contents: \ngot  %+v\nwant %+v", got, want["contents"])
 	}
 	return nil


### PR DESCRIPTION
This redefines istio.galley.v1.{Create,Update}FileRequest::contents to
contain the unmodified textual representation of istio.galley.v1.File
instead of istio.galley.v1.ConfigFile. This allows clients
(e.g. istioctl) to use istio.galley.v1.File as the canonical schema
for encoding user defined configuration files without needing to
decode/re-encode file contents to extract/override top-level fields
such as istio.galley.v1.File::path and istio.galley.v1.File::metadata.

Note: The `path` and `metadata` overrides could be further generalized to allow the client to provide overrides for _any_ fields in the encoded file contents. A similar proposal was considered for istioctl in https://github.com/istio/pilot/issues/750.