### PR TITLE
store ConfigFile messages too.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -14,6 +14,11 @@ filegroup(
     ],
 )
 
+filegroup(
+    name = "service_proto",
+    srcs = ["galley/v1/service.proto"],
+)
+
 go_proto_compile(
     name = "galley/v1_pb",
     importmap = {

--- a/pkg/server/BUILD
+++ b/pkg/server/BUILD
@@ -12,11 +12,13 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//api:galley/v1",
+        "//api:galley/v1",  # keep
+        "//pkg/server/internal:go_default_library",
         "//pkg/store:go_default_library",
         "//pkg/store/inventory:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
@@ -32,16 +34,18 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "common_test.go",
         "marshaler_test.go",
         "service_test.go",
-        "testcommon.go",
         "util_test.go",
     ],
     library = ":go_default_library",
     deps = [
-        "//api:galley/v1",
+        "//api:galley/v1",  # keep
         "//pkg/store/memstore:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",

--- a/pkg/server/BUILD
+++ b/pkg/server/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//api:galley/v1",
         "//pkg/store:go_default_library",
         "//pkg/store/inventory:go_default_library",
+        "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes/empty:go_default_library",
@@ -33,6 +34,8 @@ go_test(
     srcs = [
         "marshaler_test.go",
         "service_test.go",
+        "testcommon.go",
+        "util_test.go",
     ],
     library = ":go_default_library",
     deps = [

--- a/pkg/server/common_test.go
+++ b/pkg/server/common_test.go
@@ -25,7 +25,6 @@ import (
 	galleypb "istio.io/galley/api/galley/v1"
 )
 
-// nolint: deadcode
 const testConfig = `
 scope: shipping.FQDN
 name: service.cfg
@@ -100,7 +99,6 @@ config:
         weight: 100
 `
 
-// nolint: deadcode
 func newConfigFileForTest(fileContent string) (*galleypb.ConfigFile, []byte, error) {
 	configFile := &galleypb.ConfigFile{}
 	jsonData, err := yaml.YAMLToJSON([]byte(fileContent))

--- a/pkg/server/internal/BUILD
+++ b/pkg/server/internal/BUILD
@@ -1,0 +1,29 @@
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "go_default_library",
+    importmap = {
+        "api/galley/v1/config_object.proto": "istio.io/galley/api/galley/v1",
+        "api/galley/v1/service.proto": "istio.io/galley/api/galley/v1",
+    },
+    imports = [
+        "external/com_github_google_protobuf/src",
+        "external/com_github_googleapis_googleapis",
+    ],
+    inputs = [
+        "//api:galley_core_protos",
+        "//api:service_proto",
+        "@com_github_google_protobuf//:well_known_protos",
+        "@com_github_googleapis_googleapis//:annotations_proto",
+        "@com_github_googleapis_googleapis//:status_proto",
+    ],
+    protos = [
+        "file.proto",
+    ],
+    verbose = 0,
+    visibility = ["//pkg/server:__subpackages__"],
+    deps = [
+        "//api:galley/v1",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)

--- a/pkg/server/internal/file.proto
+++ b/pkg/server/internal/file.proto
@@ -1,0 +1,28 @@
+// Copyright 2017 Istio Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package istio.galley.internal;
+
+import "api/galley/v1/config_object.proto";
+import "api/galley/v1/service.proto";
+
+// internal.File is the message to bundle galley's File and ConfigFile
+message File {
+    //The original source data in the config.
+    istio.galley.v1.File raw_file = 1;
+
+    // The structured data used for watchers and validators.
+    istio.galley.v1.ConfigFile encoded = 2;
+}

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -66,8 +66,8 @@ func (s *GalleyService) createOrUpdate(ctx context.Context, file *galleypb.File,
 	ifile := &internalpb.File{RawFile: file}
 
 	cfile, err := newConfigFile(file.Contents, ctype)
-	if err != nil && glog.V(3) {
-		glog.Infof("the file contents can't be parsed as ConfigFile message: %v", err)
+	if err != nil {
+		glog.V(3).Infof("the file contents can't be parsed as ConfigFile message: %v", err)
 	}
 	if cfile != nil {
 		// TODO: use File's metadata? see https://github.com/istio/galley/issues/55

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -78,80 +78,6 @@ func (tm *testManager) close() {
 	tm.server.GracefulStop()
 }
 
-const testConfig = `
-scope: shipping.FQDN
-name: service.cfg
-config:
-  - type: constructor
-    name: request_count
-    spec:
-      labels:
-        dc: target.data_center
-        service: target.service
-      value: request.size
-  - type: handler
-    name: mystatsd
-    spec:
-      impl: istio.io/statsd
-      params:
-        host: statshost.FQDN
-        port: 9080
-  - type: rule
-    spec:
-      handler: $mystatsd
-      instances:
-      - $request_count
-      selector: target.service == "shipping.FQDN"
-  - type: constructor
-    name: deny_source_ip
-    spec:
-      value: request.source_ip
-  - type: rule
-    spec:
-      handler: $mesh.denyhandler
-      instances:
-      - $deny_source_ip
-      selector: target.service == "shipping.FQDN" && source.labels["app"] != "billing"
-## Proxy rules
-  - type: route-rule
-    spec:
-      destination: billing.FQDN
-      source: shipping.FQDN
-      match:
-        httpHeaders:
-          cookie:
-            regex: "^(.*?;)?(user=test-user)(;.*)?$"
-      route:
-      - tags:
-          version: v1
-        weight: 100
-      httpFault:
-        delay:
-          percent: 5
-          fixedDelay: 2s
-  - type: route-rule
-    spec:
-      destination: shipping.FQDN
-      match:
-        httpHeaders:
-          cookie:
-            regex: "^(.*?;)?(user=test-user)(;.*)?$"
-      route:
-      - tags:
-          version: v1
-        weight: 90
-      - tags:
-          version: v2
-        weight: 10
-  - type: route-rule
-    spec:
-      destination: shipping.FQDN
-      route:
-      - tags:
-          version: v1
-        weight: 100
-`
-
 func TestCRUD(t *testing.T) {
 	tm := &testManager{}
 	err := tm.setup()
@@ -206,6 +132,10 @@ func TestCRUD(t *testing.T) {
 	if len(rev) != 1 {
 		t.Errorf("Unexpected revision data: %+v", rev)
 	}
+	_, _, err = tm.s.Get(ctx, encodedPath(p1))
+	if err != nil {
+		t.Errorf("can't find the encoded data: %v", err)
+	}
 
 	_, err = tm.client.CreateFile(ctx, &galleypb.CreateFileRequest{
 		Path:     p2,
@@ -251,6 +181,9 @@ func TestCRUD(t *testing.T) {
 	file, err = tm.client.GetFile(ctx, &galleypb.GetFileRequest{Path: p1})
 	if err == nil {
 		t.Errorf("Unexpectedly get %s: %+v", p1, file)
+	}
+	if _, _, err = tm.s.Get(ctx, encodedPath(p1)); err == nil {
+		t.Errorf("encoded data is not deleted")
 	}
 	_, err = tm.client.DeleteFile(ctx, &galleypb.DeleteFileRequest{Path: p2})
 	if err != nil {

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -132,10 +132,6 @@ func TestCRUD(t *testing.T) {
 	if len(rev) != 1 {
 		t.Errorf("Unexpected revision data: %+v", rev)
 	}
-	_, _, err = tm.s.Get(ctx, encodedPath(p1))
-	if err != nil {
-		t.Errorf("can't find the encoded data: %v", err)
-	}
 
 	_, err = tm.client.CreateFile(ctx, &galleypb.CreateFileRequest{
 		Path:     p2,
@@ -181,9 +177,6 @@ func TestCRUD(t *testing.T) {
 	file, err = tm.client.GetFile(ctx, &galleypb.GetFileRequest{Path: p1})
 	if err == nil {
 		t.Errorf("Unexpectedly get %s: %+v", p1, file)
-	}
-	if _, _, err = tm.s.Get(ctx, encodedPath(p1)); err == nil {
-		t.Errorf("encoded data is not deleted")
 	}
 	_, err = tm.client.DeleteFile(ctx, &galleypb.DeleteFileRequest{Path: p2})
 	if err != nil {

--- a/pkg/server/testcommon.go
+++ b/pkg/server/testcommon.go
@@ -1,0 +1,118 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
+	galleypb "istio.io/galley/api/galley/v1"
+)
+
+// nolint: deadcode
+const testConfig = `
+scope: shipping.FQDN
+name: service.cfg
+config:
+  - type: constructor
+    name: request_count
+    spec:
+      labels:
+        dc: target.data_center
+        service: target.service
+      value: request.size
+  - type: handler
+    name: mystatsd
+    spec:
+      impl: istio.io/statsd
+      params:
+        host: statshost.FQDN
+        port: 9080
+  - type: rule
+    spec:
+      handler: $mystatsd
+      instances:
+      - $request_count
+      selector: target.service == "shipping.FQDN"
+  - type: constructor
+    name: deny_source_ip
+    spec:
+      value: request.source_ip
+  - type: rule
+    spec:
+      handler: $mesh.denyhandler
+      instances:
+      - $deny_source_ip
+      selector: target.service == "shipping.FQDN" && source.labels["app"] != "billing"
+## Proxy rules
+  - type: route-rule
+    spec:
+      destination: billing.FQDN
+      source: shipping.FQDN
+      match:
+        httpHeaders:
+          cookie:
+            regex: "^(.*?;)?(user=test-user)(;.*)?$"
+      route:
+      - tags:
+          version: v1
+        weight: 100
+      httpFault:
+        delay:
+          percent: 5
+          fixedDelay: 2s
+  - type: route-rule
+    spec:
+      destination: shipping.FQDN
+      match:
+        httpHeaders:
+          cookie:
+            regex: "^(.*?;)?(user=test-user)(;.*)?$"
+      route:
+      - tags:
+          version: v1
+        weight: 90
+      - tags:
+          version: v2
+        weight: 10
+  - type: route-rule
+    spec:
+      destination: shipping.FQDN
+      route:
+      - tags:
+          version: v1
+        weight: 100
+`
+
+// nolint: deadcode
+func newConfigFileForTest(fileContent string) (*galleypb.ConfigFile, []byte, error) {
+	configFile := &galleypb.ConfigFile{}
+	jsonData, err := yaml.YAMLToJSON([]byte(fileContent))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to convert into json: %v", err)
+	}
+	if err = jsonpb.Unmarshal(bytes.NewBuffer(jsonData), configFile); err != nil {
+		return nil, nil, fmt.Errorf("failed to unmarshal: %v", err)
+	}
+	configBytes, err := proto.Marshal(configFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal: %v", err)
+	}
+	return configFile, configBytes, nil
+}

--- a/pkg/server/util_test.go
+++ b/pkg/server/util_test.go
@@ -1,0 +1,68 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/protobuf/proto"
+
+	galleypb "istio.io/galley/api/galley/v1"
+)
+
+func TestNewConfigFile(t *testing.T) {
+	yamlConfig := []byte(testConfig)
+	jsonConfig, err := yaml.YAMLToJSON(yamlConfig)
+	if err != nil {
+		t.Fatalf("failed to convert yaml data: %v", err)
+	}
+	configFile, _, err := newConfigFileForTest(testConfig)
+	if err != nil {
+		t.Fatalf("failed to convert get the config file: %v", err)
+	}
+	textConfig := []byte(proto.MarshalTextString(configFile))
+	for _, cc := range []struct {
+		msg    string
+		source []byte
+		ctype  galleypb.ContentType
+		ok     bool
+	}{
+		{"yaml", yamlConfig, galleypb.ContentType_UNKNOWN, true},
+		{"yaml", yamlConfig, galleypb.ContentType_YAML, true},
+		{"yaml", yamlConfig, galleypb.ContentType_JSON, false},
+		{"yaml", yamlConfig, galleypb.ContentType_PROTO_TEXT, false},
+		{"json", jsonConfig, galleypb.ContentType_UNKNOWN, true},
+		{"json", jsonConfig, galleypb.ContentType_JSON, true},
+		{"json", jsonConfig, galleypb.ContentType_PROTO_TEXT, false},
+		{"proto", textConfig, galleypb.ContentType_UNKNOWN, true},
+		{"proto", textConfig, galleypb.ContentType_YAML, false},
+		{"proto", textConfig, galleypb.ContentType_JSON, false},
+		{"proto", textConfig, galleypb.ContentType_PROTO_TEXT, true},
+	} {
+		t.Run(fmt.Sprintf("%s/%s", cc.msg, cc.ctype), func(tt *testing.T) {
+			result, err := newConfigFile(string(cc.source), cc.ctype)
+			succeeded := err == nil
+			if cc.ok != succeeded {
+				tt.Errorf("got %v, want %v (error: %v)", succeeded, cc.ok, err)
+			}
+			if cc.ok && !reflect.DeepEqual(result, configFile) {
+				tt.Errorf("got %+v, want %+v", result, configFile)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The "ConfigFile" message needs to appear in the server,
since Galley needs to communicate with validator / transformer /
watcher clients with this format.

This PR only stores the ConfigFile message. Use of the stored
data should be handled in upcoming PRs.