### PR TITLE
fix normalization of paths in Galley service

### DIFF
--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -87,7 +87,7 @@ func TestCRUD(t *testing.T) {
 	defer tm.close()
 
 	p1 := "/dept1/svc1/service.cfg"
-	p2 := "/dept2/svc1/service.cfg"
+	p2 := "dept2/svc1/service.cfg"
 	ctx := context.Background()
 	file, err := tm.client.GetFile(ctx, &galleypb.GetFileRequest{Path: p1})
 	if err == nil {
@@ -115,15 +115,15 @@ func TestCRUD(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get the file: %v", err)
 	}
-	if file.Path != p1 || file.Contents != testConfig {
+	if file.Path != p1[1:] || file.Contents != testConfig {
 		t.Errorf("Got %v, Want %v", file, &galleypb.File{Path: p1, Contents: testConfig})
 	}
 	path, ok := header["file-path"]
 	if !ok {
 		t.Errorf("file-path not found in header")
 	}
-	if !reflect.DeepEqual(path, []string{p1}) {
-		t.Errorf("Got %+v, Want %+v", path, []string{p1})
+	if !reflect.DeepEqual(path, []string{p1[1:]}) {
+		t.Errorf("Got %+v, Want %+v", path, []string{p1[1:]})
 	}
 	rev, ok := header["file-revision"]
 	if !ok {
@@ -166,7 +166,7 @@ func TestCRUD(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to list files: %v", err)
 	}
-	if len(resp.Entries) != 1 || resp.Entries[0].Path != p1 || resp.Entries[0].Contents != testConfig {
+	if len(resp.Entries) != 1 || resp.Entries[0].Path != p1[1:] || resp.Entries[0].Contents != testConfig {
 		t.Errorf("Unexpected list result: %+v", resp)
 	}
 

--- a/pkg/server/util.go
+++ b/pkg/server/util.go
@@ -17,8 +17,10 @@ package server
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
@@ -28,6 +30,23 @@ import (
 	internalpb "istio.io/galley/pkg/server/internal"
 	"istio.io/galley/pkg/store"
 )
+
+// normalizePath normalizes the path -- especially removing leading and trailing
+// slashes.
+func normalizePath(path string) string {
+	if strings.HasSuffix(path, "/") {
+		glog.V(2).Infof("path %s ends with /", path)
+	}
+	path = strings.Trim(path, "/")
+	if glog.V(2) {
+		lastSlash := strings.LastIndex(path, "/")
+		lastDot := strings.LastIndex(path, ".")
+		if lastDot < 0 || lastDot < lastSlash {
+			glog.Infof("extensions not found in path %s", path)
+		}
+	}
+	return path
+}
 
 func sendFileHeader(ctx context.Context, file *galleypb.File) error {
 	return grpc.SendHeader(ctx, metadata.Pairs(

--- a/pkg/store/etcd/etcdstore.go
+++ b/pkg/store/etcd/etcdstore.go
@@ -54,10 +54,7 @@ func (es *Store) Close() error {
 }
 
 func normalizeKey(key string) string {
-	if !strings.HasPrefix(key, "/") {
-		return "/" + key
-	}
-	return key
+	return "/" + key
 }
 
 // Get implements store.Reader interface.
@@ -88,7 +85,7 @@ func (es *Store) List(ctx context.Context, prefix string) (map[string][]byte, in
 	}
 	data := map[string][]byte{}
 	for _, kvs := range resp.Kvs {
-		data[string(kvs.Key)] = kvs.Value
+		data[string(kvs.Key[1:])] = kvs.Value
 	}
 	return data, resp.Header.Revision, nil
 }
@@ -144,7 +141,8 @@ func (es *Store) Watch(ctx context.Context, key string, revision int64) (<-chan 
 			for _, ev := range resp.Events {
 				sev := store.Event{
 					Revision: resp.Header.Revision,
-					Key:      string(ev.Kv.Key),
+					// Key is normalized, i.e. always starts with /. This should be removed.
+					Key: string(ev.Kv.Key[1:]),
 				}
 				if ev.Type == mvccpb.PUT {
 					sev.Type = store.PUT


### PR DESCRIPTION
I've noticed that normally a path for REST API requests usually
does not starts with / (because the path spec is `/v1/{path=**}`.

It could came to a confusion if paths in gRPC requests start with
a slash. Thus Galley server normalizes the path to ensure that
the path does not start with slashes at least for the internal
form.

On the other hand, etcd storage adopter has another wrong
normalization -- the key conditionally starts with /, which
also complicates the watching or getting the responses.

So on the etcd side, it should always add the slash when a key
comes in and and remove the slash when the key goes out.