### PR TITLE
minor style fixes

### DIFF
--- a/pkg/client/file/file.go
+++ b/pkg/client/file/file.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	galleypb "istio.io/galley/api/galley/v1"
-
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/struct"
+
+	galleypb "istio.io/galley/api/galley/v1"
 )
 
 // File provides a container for common file request and response

--- a/pkg/client/file/file_test.go
+++ b/pkg/client/file/file_test.go
@@ -19,12 +19,12 @@ import (
 	"reflect"
 	"testing"
 
-	galleypb "istio.io/galley/api/galley/v1"
-
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/struct"
+
+	galleypb "istio.io/galley/api/galley/v1"
 )
 
 func TestPartialDecode(t *testing.T) {
@@ -50,7 +50,7 @@ func TestPartialDecode(t *testing.T) {
 		t.Fatalf("could not create YAML test content: %v", err)
 	}
 	var pb structpb.Struct
-	if err := jsonpb.UnmarshalString(string(wantContentJSON), &pb); err != nil {
+	if err = jsonpb.UnmarshalString(string(wantContentJSON), &pb); err != nil {
 		t.Fatalf("could not create temp protobuf for ProtoText test content: %v", err)
 	}
 	wantContentProto, err := proto.Marshal(&pb)


### PR DESCRIPTION
- reordering of import paths by ./bin/fmt.sh
- somehow linters.sh report an error of shadowing variables.
  fortunately this line doesn't have to redeclare the err.

linters error message:

```
pkg/client/file/file_test.go:53::warning: declaration of "err" shadows
declaration at pkg/client/file/file_test.go:44 (vetshadow)
```