### PR TITLE
implement istioctl CRUD operations

### DIFF
--- a/cmd/istioctl/cmd/BUILD
+++ b/cmd/istioctl/cmd/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "common.go",
         "completion.go",
         "create.go",
         "delete.go",
@@ -12,7 +13,11 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//api:galley/v1",  # keep
         "//cmd/shared:go_default_library",
+        "//pkg/client:go_default_library",
+        "//pkg/client/config:go_default_library",
+        "//pkg/client/file:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/cmd/istioctl/cmd/common.go
+++ b/cmd/istioctl/cmd/common.go
@@ -1,0 +1,28 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "fmt"
+
+func validateFilenames(filenames []string) error {
+	// TODO - refactor to accept input from stdin, http, multiple files?
+	if len(filenames) == 0 {
+		return fmt.Errorf("no filenames specified")
+	}
+	if len(filenames) > 1 {
+		return fmt.Errorf("multiple input filenames not supported") // TODO?
+	}
+	return nil
+}

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -22,6 +22,7 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -132,6 +133,11 @@ func LoadFromFile(filename string) (*Config, error) {
 	return load(file, filename)
 }
 
+// LoadFromString loads a user configuration from the input string.
+func LoadFromString(in string) (*Config, error) {
+	return load(bytes.NewReader([]byte(in)), "")
+}
+
 // UserFilename returns the filename of the user configuration file.
 func UserFilename() (string, error) {
 	if name := os.Getenv(PathEnvVar); name != "" {
@@ -151,6 +157,25 @@ func LoadFromDefault() (*Config, error) {
 		return nil, err
 	}
 	return LoadFromFile(filename)
+}
+
+const defaultCurrentContext = "default"
+
+// New creates a new instance of a configuration object based on the
+// default user filename. This can be subsequently updated and saved
+// to create the default user configuration.
+func New() (*Config, error) {
+	filename, err := UserFilename()
+	if err != nil {
+		return nil, err
+	}
+	return &Config{
+		CurrentContext: defaultCurrentContext,
+		Contexts: map[string]*Context{
+			defaultCurrentContext: {},
+		},
+		origin: filename,
+	}, nil
 }
 
 // Save saves the in-memory user configuration to the originating

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -150,7 +149,7 @@ func TestConfigLoad(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		got, err := load(bytes.NewReader([]byte(c.in)), "")
+		got, err := LoadFromString(c.in)
 		if c.wantErr {
 			if err == nil {
 				t.Errorf("%v: succeeded but should have failed", c.name)
@@ -193,7 +192,7 @@ func TestConfigLoadFromFile(t *testing.T) {
 }
 
 func TestConfigUseContext(t *testing.T) {
-	cfg, err := load(bytes.NewReader([]byte(caseMultipleContextsYAML)), "")
+	cfg, err := LoadFromString(caseMultipleContextsYAML)
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}


### PR DESCRIPTION
Implement the basic CRUD operations for istioctl with the Galley
service. This makes use of //pkg/client, //pkg/client/config and
//pkg/client/file to do most of the heavy lifting and the top-level
command functions focus on interpreting user intent via flags and
subcommand arguments.

note: e2e integration tests TBD